### PR TITLE
Support custom converter for `Result`

### DIFF
--- a/src/main/kotlin/me/yujinyan/retrofit/SuspendResultCallAdapterFactory.kt
+++ b/src/main/kotlin/me/yujinyan/retrofit/SuspendResultCallAdapterFactory.kt
@@ -31,7 +31,7 @@ public class SuspendResultCallAdapterFactory(
   }
 
   /**
-   * Represents Type `Call<T>`, where `T` * is passed in [dataType]
+   * Represents Type `Call<T>`, where `T` is passed in [dataType]
    */
   private class CallDataType(
     private val dataType: Type

--- a/src/main/kotlin/me/yujinyan/retrofit/SuspendResultCallAdapterFactory.kt
+++ b/src/main/kotlin/me/yujinyan/retrofit/SuspendResultCallAdapterFactory.kt
@@ -20,17 +20,18 @@ public class SuspendResultCallAdapterFactory(
 
   private var hasConverterForResult: Boolean? = null
   private fun Retrofit.hasConverterForResultType(resultType: Type): Boolean {
-    return if (hasConverterForResult == true) true else this@SuspendResultCallAdapterFactory.run {
-      runCatching {
-        nextResponseBodyConverter<Result<*>>(
-          null, resultType, arrayOf()
-        )
-      }.isSuccess.also { hasConverterForResult = it }
-    }
+    // If converter exists for any `Result<T>`,
+    // user registered custom converter for `Result` type.
+    // No need to check again.
+    return if (hasConverterForResult == true) true else runCatching {
+      nextResponseBodyConverter<Result<*>>(
+        null, resultType, arrayOf()
+      )
+    }.isSuccess.also { hasConverterForResult = it }
   }
 
   /**
-   * Represents Type Call<T>
+   * Represents Type `Call<T>`, where `T` * is passed in [dataType]
    */
   private class CallDataType(
     private val dataType: Type
@@ -57,7 +58,6 @@ public class SuspendResultCallAdapterFactory(
 
     val dataType = getParameterUpperBound(0, resultType)
 
-    // Call<T>
     val delegateType = if (retrofit.hasConverterForResultType(resultType))
       returnType else CallDataType(dataType)
 
@@ -106,7 +106,7 @@ public class SuspendResultCallAdapterFactory(
 
     override fun clone(): Call<Result<*>> = CatchingCall(delegate, failureHandler)
     override fun execute(): Response<Result<*>> =
-      throw UnsupportedOperationException("No blocking call in suspend function.")
+      throw UnsupportedOperationException("Suspend function should not be blocking.")
 
     override fun isExecuted(): Boolean = delegate.isExecuted
     override fun cancel(): Unit = delegate.cancel()

--- a/src/test/kotlin/me/yujinyan/retrofit/CustomConverterTest.kt
+++ b/src/test/kotlin/me/yujinyan/retrofit/CustomConverterTest.kt
@@ -1,0 +1,111 @@
+package me.yujinyan.retrofit
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.Test
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.create
+
+class CustomConverterTest {
+
+  private val server = MockWebServer()
+
+  private val moshi = Moshi.Builder()
+    .add(MoshiResultTypeAdapterFactory())
+    .addLast(KotlinJsonAdapterFactory())
+    .build()
+
+  private val retrofit = Retrofit.Builder()
+    .baseUrl(server.url("/"))
+    .addCallAdapterFactory(SuspendResultCallAdapterFactory {
+      println("caught error: $it")
+    })
+    .addConverterFactory(MoshiConverterFactory.create(moshi))
+    .build()
+
+  private val api = retrofit.create<UserApi>()
+
+  @Test
+  fun `successful request`() = runBlocking {
+    MockResponse().setBody(
+      """ 
+        {
+          "errcode": 0,
+          "data": {"id": 1, "name": "Peter"} 
+        }
+      """
+    ).also { server.enqueue(it) }
+
+    api.getUser(1).should {
+      it.isSuccess shouldBe true
+      it.getOrThrow().name shouldBe "Peter"
+    }
+  }
+
+  @Test
+  fun `server returned business error`() = runBlocking {
+    MockResponse().setBody(
+      """ 
+        {
+          "errcode": 500,
+          "msg": "Whoops."
+        }
+      """
+    ).also { server.enqueue(it) }
+
+    api.getUser(1).should {
+      it.isSuccess shouldBe false
+      it.exceptionOrNull()
+        .shouldNotBeNull()
+        .message shouldBe "Whoops."
+    }
+  }
+
+  @Test
+  fun `http 500`() = runBlocking {
+    MockResponse().setResponseCode(500).setBody("Server Error")
+      .also { server.enqueue(it) }
+
+    api.getUser(1).should {
+      it.isSuccess shouldBe false
+      it.exceptionOrNull().shouldBeTypeOf<HttpException>()
+        .code() shouldBe 500
+    }
+  }
+
+  @Test
+  fun `invalid json`() = runBlocking {
+    MockResponse().setResponseCode(200).setBody("some gibberish ...")
+      .also { server.enqueue(it) }
+
+    api.getUser(1).should {
+      it.isSuccess shouldBe false
+      it.exceptionOrNull().shouldBeTypeOf<JsonEncodingException>()
+    }
+  }
+
+  @Test
+  fun `json data mismatch`() = runBlocking {
+    MockResponse().setResponseCode(200).setBody(
+      """
+      {"foo": 1, "bar": 2}
+    """
+    ).also { server.enqueue(it) }
+
+    api.getUser(1).should {
+      it.isSuccess shouldBe false
+      it.exceptionOrNull().shouldBeTypeOf<JsonDataException>()
+    }
+  }
+}

--- a/src/test/kotlin/me/yujinyan/retrofit/CustomConverterTest.kt
+++ b/src/test/kotlin/me/yujinyan/retrofit/CustomConverterTest.kt
@@ -48,6 +48,7 @@ class CustomConverterTest {
     api.getUser(1).should {
       it.isSuccess shouldBe true
       it.getOrThrow().name shouldBe "Peter"
+      it.getOrThrow().id shouldBe 1
     }
   }
 

--- a/src/test/kotlin/me/yujinyan/retrofit/MockWebServerExtensions.kt
+++ b/src/test/kotlin/me/yujinyan/retrofit/MockWebServerExtensions.kt
@@ -1,0 +1,15 @@
+package me.yujinyan.retrofit
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+
+fun MockWebServer.enqueueResponse(
+  string: String,
+  block: (MockResponse.() -> Unit)? = null
+): MockResponse = MockResponse().setBody(string)
+  .apply {
+    if (block != null) {
+      block()
+    }
+  }
+  .also { enqueue(it) }

--- a/src/test/kotlin/me/yujinyan/retrofit/MoshiResultTypeAdapterFactory.kt
+++ b/src/test/kotlin/me/yujinyan/retrofit/MoshiResultTypeAdapterFactory.kt
@@ -47,10 +47,12 @@ class MoshiResultTypeAdapterFactory : JsonAdapter.Factory {
 
       if (errcode == null) throw JsonDataException("Expected field errcode not present.")
 
-      return if (errcode != 0) throw RuntimeException(msg)
+      return if (errcode != 0) throw BusinessException(errcode, msg)
       else data as T
     }
 
     override fun toJson(writer: JsonWriter, value: T?): Unit = TODO("Not yet implemented")
   }
 }
+
+class BusinessException(val code: Int, message: String?) : RuntimeException(message)

--- a/src/test/kotlin/me/yujinyan/retrofit/MoshiResultTypeAdapterFactory.kt
+++ b/src/test/kotlin/me/yujinyan/retrofit/MoshiResultTypeAdapterFactory.kt
@@ -1,0 +1,56 @@
+package me.yujinyan.retrofit
+
+import com.squareup.moshi.*
+import java.lang.RuntimeException
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Moshi [JsonAdapter.Factory] that deserializes JSON string with following structure.
+ * ```
+ * {
+ *   "errcode": 0,
+ *   "data": {"id": 1, "name": "Peter"}
+ * }
+ * ```
+ *
+ * It tries to unwrap the `data` field and place it in a [Result].
+ *
+ */
+class MoshiResultTypeAdapterFactory : JsonAdapter.Factory {
+  override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+    val rawType = type.rawType
+    if (rawType != Result::class.java) return null
+    val dataType: Type = (type as? ParameterizedType)?.actualTypeArguments?.firstOrNull() ?: return null
+    val dataTypeAdapter = moshi.nextAdapter<Any>(this, dataType, annotations)
+    return ResultTypeAdapter(dataTypeAdapter)
+  }
+
+  class ResultTypeAdapter<T>(
+    private val dataTypeAdapter: JsonAdapter<T>
+  ) : JsonAdapter<T>() {
+    override fun fromJson(reader: JsonReader): T? {
+      reader.beginObject()
+      var errcode: Int? = null
+      var msg: String? = null
+      var data: Any? = null
+
+      while (reader.hasNext()) {
+        when (reader.nextName()) {
+          "errcode" -> errcode = reader.nextString().toIntOrNull()
+          "msg" -> msg = reader.nextString()
+          "data" -> data = dataTypeAdapter.fromJson(reader)
+          else -> reader.skipValue()
+        }
+      }
+      reader.endObject()
+
+      if (errcode == null) throw JsonDataException("Expected field errcode not present.")
+
+      return if (errcode != 0) throw RuntimeException(msg)
+      else data as T
+    }
+
+    override fun toJson(writer: JsonWriter, value: T?): Unit = TODO("Not yet implemented")
+  }
+}

--- a/src/test/kotlin/me/yujinyan/retrofit/MoshiResultTypeAdapterFactory.kt
+++ b/src/test/kotlin/me/yujinyan/retrofit/MoshiResultTypeAdapterFactory.kt
@@ -31,6 +31,7 @@ class MoshiResultTypeAdapterFactory : JsonAdapter.Factory {
   ) : JsonAdapter<T>() {
     override fun fromJson(reader: JsonReader): T? {
       reader.beginObject()
+
       var errcode: Int? = null
       var msg: String? = null
       var data: Any? = null
@@ -45,7 +46,8 @@ class MoshiResultTypeAdapterFactory : JsonAdapter.Factory {
       }
       reader.endObject()
 
-      if (errcode == null) throw JsonDataException("Expected field errcode not present.")
+      if (errcode == null)
+        throw JsonDataException("Expected field [errcode] not present.")
 
       return if (errcode != 0) throw BusinessException(errcode, msg)
       else data as T


### PR DESCRIPTION
Previous implementation does not work when user registers custom converter for `Result` type.

https://github.com/yujinyan/retrofit-suspend-result-adapter/blob/master/src/test/kotlin/me/yujinyan/retrofit/CustomConverterTest.kt